### PR TITLE
Enforce more limits on the stack

### DIFF
--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -56,7 +56,13 @@ impl Stack {
     pub fn topnum(&self, offset: isize, require_minimal: bool) -> Result<i64, ExecError> {
         let entry = self.top(offset)?;
         match entry {
-            StackEntry::Num(v) => Ok(*v),
+            StackEntry::Num(v) => {
+                if *v <= i32::MAX as i64 {
+                    Ok(*v)
+                } else {
+                    Err(ExecError::ScriptIntNumericOverflow)
+                }
+            }
             StackEntry::StrRef(v) => Ok(read_scriptint(v.borrow().as_slice(), 4, require_minimal)?),
         }
     }
@@ -104,7 +110,13 @@ impl Stack {
     pub fn popnum(&mut self, require_minimal: bool) -> Result<i64, ExecError> {
         let entry = self.0.pop().ok_or(ExecError::InvalidStackOperation)?;
         match entry {
-            StackEntry::Num(v) => Ok(v),
+            StackEntry::Num(v) => {
+                if v <= i32::MAX as i64 {
+                    Ok(v)
+                } else {
+                    Err(ExecError::ScriptIntNumericOverflow)
+                }
+            }
             StackEntry::StrRef(v) => Ok(read_scriptint(v.borrow().as_slice(), 4, require_minimal)?),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,6 @@ const _MAX_PUBKEYS_PER_MULTISIG: i64 = 20;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Experimental {
     /// Enable an experimental implementation of OP_CAT.
-    ///
-    /// This implementation is naive and does not enforce any
-    /// additional restrictions on the stack.
     pub op_cat: bool,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ const VALIDATION_WEIGHT_OFFSET: i64 = 50;
 const VALIDATION_WEIGHT_PER_SIGOP_PASSED: i64 = 50;
 
 // Maximum number of public keys per multisig
-const MAX_PUBKEYS_PER_MULTISIG: i64 = 20;
+const _MAX_PUBKEYS_PER_MULTISIG: i64 = 20;
 
 /// Used to enable experimental script features.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -489,7 +489,7 @@ impl Exec {
                 }
 
                 match op {
-                    OP_CAT if !self.opt.experimental.op_cat => {
+                    OP_CAT if !self.opt.experimental.op_cat || self.ctx != ExecCtx::Tapscript => {
                         return self.failop(ExecError::DisabledOpcode, op);
                     }
                     OP_SUBSTR | OP_LEFT | OP_RIGHT | OP_INVERT | OP_AND | OP_OR | OP_XOR
@@ -806,12 +806,15 @@ impl Exec {
                 self.stack.push(x2);
             }
 
-            OP_CAT if self.opt.experimental.op_cat => {
+            OP_CAT if self.opt.experimental.op_cat && self.ctx == ExecCtx::Tapscript => {
                 // (x1 x2 -- x1|x2)
                 self.stack.needn(2)?;
                 let x2 = self.stack.popstr().unwrap();
                 let x1 = self.stack.popstr().unwrap();
                 let ret: Vec<u8> = x1.into_iter().chain(x2.into_iter()).collect();
+                if ret.len() > MAX_SCRIPT_ELEMENT_SIZE {
+                    return Err(ExecError::PushSize);
+                }
                 self.stack.pushstr(&ret);
             }
 
@@ -985,8 +988,6 @@ impl Exec {
                 unimplemented!();
             }
 
-            _ => unimplemented!(),
-
             // remainder
             _ => return Err(ExecError::BadOpcode),
         }
@@ -1016,6 +1017,5 @@ fn read_scriptint(item: &[u8], size: usize, minimal: bool) -> Result<i64, ExecEr
         script::ScriptIntError::NonMinimalPush => ExecError::MinimalData,
         // only possible if size is 4 or lower
         script::ScriptIntError::NumericOverflow => ExecError::ScriptIntNumericOverflow,
-        _ => unreachable!("not possible"),
     })
 }


### PR DESCRIPTION
This PR made a few additional limits that are consistent with the Bitcoin consensus:

- The current stack model may not be able to prevent inputs larger than signed 32-bit's MAX to be used in arithmetic opcodes. This PR makes the limit more explicit in the stack model.
- The experimental OP_CAT is only reactivated in tapscript, not in other execution environments.
- Enforce the output length limit for OP_CAT.

This is a backport of some other changes in https://github.com/Bitcoin-Wildlife-Sanctuary/rust-bitcoin-scriptexec-with-muldiv/commit/c5172019fec7ccc1400088936affe7870d6b02f8